### PR TITLE
Add buildtool_depend on git

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <author email="esteve.fernandez@autoware.org">Esteve Fernandez</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This isn't necessary on the Ubuntu buildfarm because git is an implicit dependency, but should be called out for platforms where git may not be present at build time (like RHEL): https://build.ros2.org/view/Gbin_rhel_el864/job/Gbin_rhel_el864__osqp_vendor__rhel_8_x86_64__binary/3/console