### PR TITLE
Always preserve source permissions in vendor packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ macro(build_osqp)
       ${CMAKE_CURRENT_BINARY_DIR}/osqp_install/
     DESTINATION
       ${CMAKE_INSTALL_PREFIX}
+    USE_SOURCE_PERMISSIONS
     PATTERN config.h EXCLUDE
   )
 endmacro()


### PR DESCRIPTION
In vendor packages where we're installing an executable, we use USE_SOURCE_PERMISSIONS to make sure that the executable permissions on the binaries are maintained when the external project's staging directory is recursively installed to the final installation directory.

In most of our vendor packages, we aren't using that flag where we don't expect an executable binary to be installed. However, for reasons I won't go into here, some systems use executable permissions on shared object libraries as well. The linker seems to handle this on our behalf, but we're losing the permissions during the recursive copy operation if we don't use this flag.

We've made this same change in many ROS 2 vendor packages, for example: ros2/mimick_vendor#19