### PR TITLE
Suppress CMake 'update' step in external projects 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ macro(build_osqp)
     GIT_TAG ${git_tag}
     GIT_SHALLOW ON
     TIMEOUT 60
+    # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+    UPDATE_COMMAND ""
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/osqp_install
       ${extra_cmake_args}


### PR DESCRIPTION
When using a GIT_REPOSITORY source for a CMake external project, CMake performs an "update" step whenever the external project is evaluated. The idea is to update to the latest ref of the branch prior to invoking the configure/build/install commands, ensuring the target is fully up-to-date.

There are two reasons we want to suppress this step here:
1. You're targeting a specific tag, which means that unless the tag changes, the code won't ever change (unlike the HEAD of a branch might).
2. The update step invalidates the build target, so the project gets rebuilt during the package's install phase. This isn't always a problem, but the debian builds invoke the install phase with the DESTDIR variable set, which messes up the external project's installation to the staging directory. You end up with a bunch of files in the deb under /tmp/debbuild that shouldn't be there. For RHEL builds, this installing files outside of /opt/ros will fail the build.

This is the same pattern we're using in the various vendor packages under the ros2 org on GitHub, for example: ros2/mimick_vendor#17