### PR TITLE
Update osqp version to v1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(osqp_vendor)
 find_package(ament_cmake REQUIRED)
 
 macro(build_osqp)
-  set(git_tag "v0.6.3")
+  set(git_tag "v1.0.0")
   set(extra_cmake_args)
 
   get_property(multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)


### PR DESCRIPTION
OSQP released a 1.0.0 version a little over a year ago, and we have an incoming ROS package that relies on this version.

Any interest in giving this a go?

Closes https://github.com/tier4/osqp_vendor/issues/24